### PR TITLE
Support for blog index in another URL different from '/'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ author:
   url:            https://twitter.com/fongandrewc
 
 paginate:         5
+#paginate_path:    '/page:num'
 
 plugins:
   - jekyll-feed
@@ -23,5 +24,6 @@ plugins:
 # Custom vars
 version:            3.4.1
 sidebar_home_link:  true
+#sidebar_blog_link:  '/'
 github:
   repo:             https://github.com/fongandrew/hydeout

--- a/_includes/pagination-newer.html
+++ b/_includes/pagination-newer.html
@@ -1,7 +1,7 @@
 {% if paginator.previous_page %}
 <div class="pagination">
   <a class="pagination-item newer"
-     href="{{ site.baseurl }}/{% unless paginator.page == 2 %}page{{ paginator.previous_page }}{% endunless %}">
+     href="{{ site.baseurl }}{{ paginator.previous_page_path }}">
     Newer
   </a>
 </div>

--- a/_includes/pagination-older.html
+++ b/_includes/pagination-older.html
@@ -1,7 +1,7 @@
 {% if paginator.next_page %}
 <div class="pagination">
   <a class="pagination-item older"
-     href="{{ site.baseurl }}/page{{paginator.next_page}}">
+     href="{{ site.baseurl }}{{ paginator.next_page_path }}">
     Older
   </a>
 </div>

--- a/_includes/sidebar-nav-links.html
+++ b/_includes/sidebar-nav-links.html
@@ -3,6 +3,10 @@
     <a class="home-link {% if page.url == '/' %} active{% endif %}"
         href="{{ site.baseurl }}/">Home</a>
   {% endif %}
+  {% if site.sidebar_blog_link %}
+    <a class="page-link {% if page.url == site.sidebar_blog_link %} active{% endif %}"
+	href="{{ site.baseurl }}{{ site.sidebar_blog_link }}">Blog</a>
+  {% endif %}
 
   {% comment %}
     The code below dynamically generates a sidebar nav of pages with


### PR DESCRIPTION
To put the blog index in a different path from '/' such as '/blog':

1. move the 'index.html' file to '/blog/index.html'.
2. create a new 'index.html' or 'index.md' file to have a new index page for your website.
3. edit '_config.yml':
    * paginate_path:      "/blog/page:num/"
    * sidebar_blog_link:  "/blog/"

This is working for me in https://github.com/chrpinedo/chrpinedo.github.io and http://christianpinedo.me.

Thanks