### PR TITLE
Check for tagline

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
   <title>
     {% if page.title == "Home" %}
-      {{ site.title }} &middot; {{ site.tagline }}
+      {{ site.title }}{% if site.tagline %} &middot; {{ site.tagline }}{% endif %}
     {% else %}
       {{ page.title }} &middot; {{ site.title }}
     {% endif %}


### PR DESCRIPTION
This PR checks that a tagline exists, so that the homepage title doesn't have a trailing middle dot.