### PR TITLE
Make Disqus js available over non-https as well

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -19,7 +19,7 @@
   }
   function loadDisqusComments() { // DON'T EDIT BELOW THIS LINE
     var d = document, s = d.createElement('script');
-    s.src = 'https://{{ site.disqus.shortname }}.disqus.com/embed.js';
+    s.src = '//{{ site.disqus.shortname }}.disqus.com/embed.js';
     s.setAttribute('data-timestamp', +new Date());
     (d.head || d.body).appendChild(s);
   }


### PR DESCRIPTION
Replaced `https://{{ site.disqus.shortname }}.disqus.com/embed.js` with `//{{ site.disqus.shortname }}.disqus.com/embed.js`. Browsers will not load the https content if the parent page is served over http. This breaks for example Github Pages. GH pages with custom domain cannot be served over https.