### PR TITLE
add .html to page links

### DIFF
--- a/_includes/page-links.html
+++ b/_includes/page-links.html
@@ -7,7 +7,7 @@
   {% if node.title != null %}
     {% if node.sidebar_link %}
       <a class="page-link {% if page.url == node.url %} active{% endif %}"
-          href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
+          href="{{ site.baseurl }}{{ node.url }}.html">{{ node.title }}</a>
     {% endif %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Ran into a problem where page links would not be found do the fact the http server did not assume .http if the ending did not exist. This fixes the problem and should never cause any majors problems that I can think of.