### PR TITLE
make use of the thing you're checking for

### DIFF
--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -19,7 +19,7 @@
 
       {% if category_page %}
         <a href="{{ site.baseurl }}{{ category_page.url }}">
-          {{ category }}
+          {{ category_page.title | default: category_page.category }}
         </a>
       {% else %}
         {{ category }}


### PR DESCRIPTION
You check for category_page variable but then dont use it or the elements that allow it to look better.

Without this, if you make a category thats slugified, then you wont be getting the pretty name you gave it in the title. This fixes that. 