### PR TITLE
Align feed.xml with jekyll-feed functionality

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   {% include favicons.html %}
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml" />
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/{{ site.feed.path | default: 'feed.xml' }}" />
 
   {% include custom-head.html %}
 </head>

--- a/_includes/sidebar-icon-links.html
+++ b/_includes/sidebar-icon-links.html
@@ -14,7 +14,7 @@
 
   <a id="subscribe-link"
      class="icon" title="Subscribe" aria-label="Subscribe"
-     href="{{ site.baseurl }}/feed.xml">
+     href="{{ site.baseurl }}/{{ site.feed.path | default: 'feed.xml' }}">
     {% include svg/feed.svg %}
   </a>
 


### PR DESCRIPTION
This change aligns the code base to conform to the documentation found here:
https://github.com/jekyll/jekyll-feed#already-have-a-feed-path

> 
> ### Already have a feed path?
> 
> Do you already have an existing feed someplace other than `/feed.xml`, but are on a host like GitHub Pages that doesn't support machine-friendly redirects? If you simply swap out `jekyll-feed` for your existing template, your existing subscribers won't continue to get updates. Instead, you can specify a non-default path via your site's config.
> 
> ```yml
> feed:
>   path: atom.xml
> ```
> 
> To note, you shouldn't have to do this unless you already have a feed you're using, and you can't or wish not to redirect existing subscribers.
> 