### PR TITLE
Fix google search site, live bookmark feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,9 @@ highlighter:      rouge
 title:            Hydeout
 tagline:          'A Jekyll theme'
 description:      'The <a href="http://hyde.getpoole.com" target="_blank">Hyde</a> theme for <a href="http://jekyllrb.com" target="_blank">Jekyll</a>, refreshed.'
-url:              https://fongandrew.github.io/hydeout
-baseurl:          # the optional subpath of your site, e.g. "/blog"
+url:              https://fongandrew.github.io
+baseurl:          '/hydeout'
+                  # the optional subpath of your site, e.g. "/blog"
                   # NB: This applies to all pages in your Jekyll site.
                   # If you want to move just the blog index pages but keep
                   # other pages at root, see the paginate_path and


### PR DESCRIPTION
- Fix google search site. (mentioned in #23)
- Fix live bookmark feed. (removing the double baseurl, `.../hydeout/hydeout/...`)