### PR TITLE
Apply bottom padding to div.content

### DIFF
--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -64,6 +64,7 @@ body {
 
   > .content {
     flex-grow: 1;
+    padding-bottom: $section-spacing * 2;
   }
 }
 
@@ -184,7 +185,9 @@ body {
   .container {
     background: $body-bg;
     color: $body-color;
-    padding: $section-spacing * 2;
+    padding: $section-spacing * 2
+             $section-spacing * 2
+             0;
     height: 100vh;
 
     > header {


### PR DESCRIPTION
Firefox and Edge clip the overflow of `main.container` at the padding edge (as according to the specs) but Chrome clips it at the content edge instead. This means that in Chrome there is bottom padding on the content, whereas in FF and Edge there is not.

Applying the bottom padding to the container's inner element (`div.content`) makes the padding uniform in all browsers.