### PR TITLE
Fixes no momentum scrolling on iOS

### DIFF
--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -146,9 +146,12 @@ body {
   body {
     flex-direction: row;
     height: 100vh;
-    overflow: auto;
-    > * { max-height: 100vh; overflow: auto; }
-  }
+    overflow-y: scroll; /* has to be scroll, not auto */
+    -webkit-overflow-scrolling: touch;
+    > * { max-height: 100vh; 
+          overflow-y: scroll; 
+          -webkit-overflow-scrolling: touch;
+          }
 
   /* Undo mobile CSS */
 


### PR DESCRIPTION
**Issue:** When desktop width view is open on iOS Safari, e.g. an iPad in landscape, momentum scrolling is broken. 

**Fix:** Small tweaks to `overflow` settings fixes. Citation: https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/

(forgive me if something isn't clear, this is my first ever pull request across repos.)