### PR TITLE
Added styling information for input fields of type email

### DIFF
--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -79,7 +79,7 @@ tbody tr:nth-child(odd) th {
   background-color: $gray-1;
 }
 
-input[type="text"], input[type="search"], input[type="submit"], button {
+input[type="text"], input[type="email"], input[type="search"], input[type="submit"], button {
   padding: $padding-v $padding-h;
   border: 1px solid $border-color;
   border-radius: $border-radius;


### PR DESCRIPTION
Mailing list sign-up forms (such as mailchimp's) use the email input type:

    <input type="email">

This commit applies the same rounded-corner styling of input fields of type text also to type email.