### PR TITLE
Replace colors in _layout.scss with SCSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ of the following SASS variables:
 
 ```scss
 $sidebar-bg-color: #202020 !default;
+$sidebar-fg-color: white !default;
 $sidebar-sticky: true !default;
 $layout-reverse: false !default;
 $link-color: #268bd2 !default;

--- a/_posts/2017-06-01-hello-hydeout.md
+++ b/_posts/2017-06-01-hello-hydeout.md
@@ -24,6 +24,7 @@ of the following SASS variables:
 
 ```scss
 $sidebar-bg-color: #202020 !default;
+$sidebar-fg-color: white !default;
 $sidebar-sticky: true !default;
 $layout-reverse: false !default;
 $link-color: #268bd2 !default;

--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -23,7 +23,7 @@
 */
 
 body {
-  color: rgba(255,255,255,.75);
+  color: $sidebar-text-color;
   background-color: $sidebar-bg-color;
   background-image: linear-gradient(
     to bottom,
@@ -43,14 +43,8 @@ body {
     font-family: "Abril Fatface", serif;
     font-weight: normal;
     font-size: $large-font-size;
-    color: rgba(255,255,255,.75);
     margin-top: 0;
     margin-bottom: $heading-spacing;
-
-    a {
-      color: inherit;
-      &:hover { color: $sidebar-title-color; }
-    }
 
     .back-arrow { margin-right: 0.5rem; }
   }
@@ -89,14 +83,14 @@ body {
 
 // Make header elements blend into sidebar / background
 .container > header {
+  color: $sidebar-title-color;
   background: transparent;
-  color: white;
   margin: ($heading-spacing - $section-spacing)
           $section-spacing
           $section-spacing;
 
   h1, h2 {
-    color: white;
+    color: inherit;
 
     &:last-child {
       margin-bottom: 0;
@@ -117,7 +111,6 @@ body {
   // Bigger title
   .site-title {
     font-size: 3.25rem;
-    color: $sidebar-title-color;
   }
 
   // Show secondary nav content + lead
@@ -170,8 +163,6 @@ body {
   #sidebar {
     .site-title {
       font-size: 3.25rem;
-
-      a { color: $sidebar-title-color; }
       .back-arrow { display: none; }
     }
 
@@ -220,14 +211,14 @@ body {
 ----------------------------------------------------------- */
 
 #sidebar a {
-  color: #fff;
+  color: $sidebar-link-color;
 
   svg {
-    fill: rgba(255, 255, 255, 0.85);
+    fill: $sidebar-icon-color;
   }
 
   &:hover, &:focus, &.active {
-    svg { fill: #fff; }
+    svg { fill: $sidebar-icon-color; }
   }
 
   &:hover, &:focus {
@@ -242,6 +233,10 @@ body {
   }
 }
 
+#sidebar .site-title {
+  color: $sidebar-title-color;
+  a { color: inherit; }
+}
 #sidebar nav {
   display: flex;
 }

--- a/_sass/hydeout/_variables.scss
+++ b/_sass/hydeout/_variables.scss
@@ -46,6 +46,11 @@ $code-color: #bf616a !default;
 
 // Hyde theming
 $sidebar-bg-color: #202020 !default;
-$sidebar-title-color: #ffffff !default;
+$sidebar-fg-color: white !default;
 $sidebar-sticky: true !default;
 $layout-reverse: false !default;
+
+$sidebar-title-color: $sidebar-fg-color !default;
+$sidebar-link-color: $sidebar-fg-color !default;
+$sidebar-text-color: rgba($sidebar-fg-color, 0.75) !default;
+$sidebar-icon-color: rgba($sidebar-fg-color, 0.85) !default;


### PR DESCRIPTION
- These edits do not change the way hydeout looks.
- The sidebar colors can be changed easily now by changing $sidebar-bg-color and $sidebar-fg-color.
- $sidebar-link-color, $sidebar-text-color, $sidebar-title-color, and $sidebar-icon-color are computed from $sidebar-fg-color, but can also be overridden individually if needed.
- Previously, some coloring was applied multiple times in _layout.scss - this redundancy is now reduced.
- The previous implementation of $sidebar-title-color was broken.