### PR TITLE
Use correct heading color in page layout on large screen

### DIFF
--- a/_sass/hydeout/_layout.scss
+++ b/_sass/hydeout/_layout.scss
@@ -196,7 +196,7 @@ body {
     height: 100vh;
 
     > header {
-      color: inherit;
+      color: $heading-color;
       margin: 0;
       h1, h2 {
         color: inherit;


### PR DESCRIPTION
The color of h1 headers was incorrectly set to $body-color instead of
$heading-color in page layout on a large screen.