### PR TITLE
use https for profile link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-  <link href="http://gmpg.org/xfn/11" rel="profile" />
+  <link href="https://gmpg.org/xfn/11" rel="profile" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 


### PR DESCRIPTION
This PR changes the profile link to use HTTPS, to avoid [Mixed Content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content) warnings