### PR TITLE
Change absolute link to relative for xml feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   {% include favicons.html %}
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/{{ site.feed.path | default: 'feed.xml' }}" />
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/{{ site.feed.path | default: 'feed.xml' | relative_url }}" />
 
   {% include custom-head.html %}
 </head>


### PR DESCRIPTION
Fix absolute path to relative path 
Note that it is easier  to use the jekyll  `relative_url` instead of prepending `baseurl`