### PR TITLE
Use relative_url Liquid filter

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,5 +6,5 @@ permalink: 404.html
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
-  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}">Head back home</a> to try finding it again.</p>
+  <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ "/" | relative_url }}">Head back home</a> to try finding it again.</p>
 </div>

--- a/_includes/category-links.html
+++ b/_includes/category-links.html
@@ -6,7 +6,7 @@
   {% if node.title != null %}
     {% if node.layout == "category" %}
       <a class="category-link {% if page.url == node.url %} active{% endif %}"
-          href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
+          href="{{ node.url | relative_url }}">{{ node.title }}</a>
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/_includes/copyright.html
+++ b/_includes/copyright.html
@@ -1,4 +1,4 @@
 <p>
   &copy; {{ site.time | date: '%Y' }}.
-  <a href="{{ site.baseurl }}/LICENSE.md">MIT License.</a>
+  <a href="{{ "/LICENSE.md" | relative_url }}">MIT License.</a>
 </p>

--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,2 +1,2 @@
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/favicon.png" />
-<link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico" />
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/favicon.png" | relative_url }}" />
+<link rel="shortcut icon" href="{{ "/favicon.ico" | relative_url}}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,14 +17,14 @@
   {% include google-analytics.html %}
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css" />
+  <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}" />
   {% include font-includes.html %}
 
   <!-- Icons -->
   {% include favicons.html %}
 
   <!-- RSS -->
-  <link rel="alternate" type="application/rss+xml" title="RSS" href="/{{ site.feed.path | default: 'feed.xml' }}" />
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ site.feed.path | default: 'feed.xml' | relative_url }}" />
 
   {% include custom-head.html %}
 </head>

--- a/_includes/page-links.html
+++ b/_includes/page-links.html
@@ -7,7 +7,7 @@
   {% if node.title != null %}
     {% if node.sidebar_link %}
       <a class="page-link {% if page.url == node.url %} active{% endif %}"
-          href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
+          href="{{ node.url | relative_url }}">{{ node.title }}</a>
     {% endif %}
   {% endif %}
 {% endfor %}

--- a/_includes/pagination-newer.html
+++ b/_includes/pagination-newer.html
@@ -1,7 +1,7 @@
 {% if paginator.previous_page %}
 <div class="pagination">
   <a class="pagination-item newer"
-     href="{{ site.baseurl }}{{ paginator.previous_page_path }}">
+     href="{{ paginator.previous_page_path | relative_url }}">
     Newer
   </a>
 </div>

--- a/_includes/pagination-older.html
+++ b/_includes/pagination-older.html
@@ -1,7 +1,7 @@
 {% if paginator.next_page %}
 <div class="pagination">
   <a class="pagination-item older"
-     href="{{ site.baseurl }}{{ paginator.next_page_path }}">
+     href="{{ paginator.next_page_path | relative_url }}">
     Older
   </a>
 </div>

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -18,7 +18,7 @@
       {% endfor %}
 
       {% if category_page %}
-        <a href="{{ site.baseurl }}{{ category_page.url }}">
+        <a href="{{ category_page.url | relative_url }}">
           {{ category_page.title | default: category_page.category }}
         </a>
       {% else %}

--- a/_includes/post-tags.html
+++ b/_includes/post-tags.html
@@ -11,7 +11,7 @@
 <div class="post-tags">
   {% for tag in include.post.tags %}
     {% if tags_page %}
-    <a href="{{ site.baseurl }}{{ tags_page.url }}#{{ tag | slugify }}">
+    <a href="{{ tags_page.url | relative_url }}#{{ tag | slugify }}">
     {% else %}<span>{% endif %}
       <span class="icon">
         {% include svg/tags.svg %}

--- a/_includes/related_posts.html
+++ b/_includes/related_posts.html
@@ -4,7 +4,7 @@
     {% for post in site.related_posts limit:3 %}
       <li>
         <h3>
-          <a href="{{ site.baseurl }}{{ post.url }}">
+          <a href="{{ post.url | relative_url }}">
             {{ post.title }}
             <small>{{ post.date | date_to_string }}</small>
           </a>

--- a/_includes/search-form.html
+++ b/_includes/search-form.html
@@ -10,7 +10,7 @@
     {% assign url = url | replace_first: 'spdy://', '' %}
     {% assign url = url | replace_first: '//', '' %}
     <input name="sitesearch" type="hidden"
-           value="{{ url }}{{ site.baseurl }}" />
+           value="{{ url }}{{ "/" | relative_url }}" />
 
     <input type="submit" value="Search" />
   </div>

--- a/_includes/sidebar-icon-links.html
+++ b/_includes/sidebar-icon-links.html
@@ -14,7 +14,7 @@
 
   <a id="subscribe-link"
      class="icon" title="Subscribe" aria-label="Subscribe"
-     href="{{ site.baseurl }}/{{ site.feed.path | default: 'feed.xml' }}">
+     href="{{ site.feed.path | default: 'feed.xml' | relative_url }}">
     {% include svg/feed.svg %}
   </a>
 
@@ -35,7 +35,7 @@
     <a id="tags-link"
        class="icon{% if page.url == '/tags' %} active{% endif %}"
        title="Tags" aria-label="Tags"
-       href="{{ site.baseurl }}{{ tags_page.url }}">
+       href="{{ tags_page.url | relative_url }}">
       {% include svg/tags.svg %}
     </a>
   {% endif %}
@@ -44,7 +44,7 @@
     <a id="search-link"
        class="icon{% if page.url == '/search' %} active{% endif %}"
        title="Search" aria-label="Search"
-       href="{{ site.baseurl }}{{ search_page.url }}">
+       href="{{ search_page.url | relative_url }}">
       {% include svg/search.svg %}
     </a>
   {% endif %}

--- a/_includes/sidebar-nav-links.html
+++ b/_includes/sidebar-nav-links.html
@@ -1,11 +1,11 @@
 <nav id="sidebar-nav-links">
   {% if site.sidebar_home_link %}
     <a class="home-link {% if page.url == '/' %} active{% endif %}"
-        href="{{ site.baseurl }}/">Home</a>
+        href="{{ "/" | relative_url }}">Home</a>
   {% endif %}
   {% if site.sidebar_blog_link %}
     <a class="page-link {% if page.url == site.sidebar_blog_link %} active{% endif %}"
-	href="{{ site.baseurl }}{{ site.sidebar_blog_link }}">Blog</a>
+	href="{{ site.sidebar_blog_link | relative_url }}">Blog</a>
   {% endif %}
 
   {% comment %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div id="sidebar">
   <header>
     <{% if page.layout == "index" %}h1{% else %}div{% endif %} class="site-title">
-      <a href="{{ site.baseurl }}/">
+      <a href="{{ "/" | relative_url }}">
         {% unless page.url == "/" %}
           <span class="back-arrow icon">{% include svg/back-arrow.svg %}</span>
         {% endunless %}

--- a/_includes/tags-list.html
+++ b/_includes/tags-list.html
@@ -27,7 +27,7 @@
         {% for post in site.tags[tag] %}
           <li>
             <h3>
-              <a href="{{ site.baseurl }}{{ post.url }}">
+              <a href="{{ post.url | relative_url }}">
                 {{ post.title }}
                 <small>{{ post.date | date_to_string }}</small>
               </a>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -11,7 +11,7 @@ layout: page
   {% for post in site.categories[category] %}
     <li>
       <h3>
-        <a href="{{ site.baseurl }}{{ post.url }}">
+        <a href="{{ post.url | relative_url }}">
           {{ post.title }}
           <small>{{ post.date | date_to_string }}</small>
         </a>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -10,7 +10,7 @@ layout: default
   {% for post in paginator.posts %}
   <article class="post-body">
     <h2 class="post-title">
-      <a href="{{ site.baseurl }}{{ post.url }}">
+      <a href="{{ post.url | relative_url }}">
         {{ post.title }}
       </a>
     </h2>
@@ -32,7 +32,7 @@ layout: default
       {% endcapture %}
 
       {% if content_words != excerpt_words %}
-        <a href="{{ site.baseurl }}{{ post.url }}">More &hellip;</a>
+        <a href="{{ post.url | relative_url }}">More &hellip;</a>
       {% endif %}
     {% endif %}
   </article>

--- a/_posts/2013-12-28-introducing-hyde.md
+++ b/_posts/2013-12-28-introducing-hyde.md
@@ -9,7 +9,7 @@ Hyde is a brazen two-column [Jekyll](http://jekyllrb.com) theme that pairs a pro
 
 Poole is the Jekyll Butler, serving as an upstanding and effective foundation for Jekyll themes by [@mdo](https://twitter.com/mdo). Poole, and every theme built on it (like Hyde here) includes the following:
 
-* Complete Jekyll setup included (layouts, config, [404](/404), [RSS feed](/feed.xml), posts, and [example page](/about))
+* Complete Jekyll setup included (layouts, config, [404]({{ "/404" | relative_url }}), [RSS feed]({{ "/feed.xml" | relative_url }}), posts, and [example page]({{ "/about" | relative_url }}))
 * Mobile friendly design and development
 * Easily scalable text and component sizing with `rem` units in the CSS
 * Support for a wide gamut of HTML elements


### PR DESCRIPTION
In version 3.3 Jekyll gained support for two new filters: `absolute_url` and `relative_url`. Those filters take the `site.url` and `site.baseurl` settings into account to construct correct URLs based on given paths.

Here's a quick overview on how the filters work: https://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/#2-relative_url-and-absolute_url-filters

This pull request changes the code so that it uses the `relative_url` filter whenever applicable. This should fix issues with empty `baseurl`s (as seen in #68) as well as issues with non-empty `baseurl`s (like in [this example post](https://fongandrew.github.io/hydeout/2013/12/28/introducing-hyde.html)).