### PR TITLE
✨ Makes Hydeout compliant with Jekyll 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hydeout
 
 Hydeout updates the original [Hyde](https://github.com/poole/hyde)
-theme for [Jekyll](http://jekyllrb.com) 3.x and adds new functionality.
+theme for [Jekyll](http://jekyllrb.com) 3.x and 4.x and adds new functionality.
 
 ![Desktop](/_screenshots/1.png?raw=true)
 <img alt="Mobile home page" src="/_screenshots/2.png?raw=true" width="300px" />

--- a/_posts/2017-06-01-hello-hydeout.md
+++ b/_posts/2017-06-01-hello-hydeout.md
@@ -5,7 +5,7 @@ excerpt_separator:  <!--more-->
 ---
 
 Hydeout updates the original [Hyde](https://github.com/poole/hyde)
-theme for [Jekyll](http://jekyllrb.com) 3.x and adds new functionality.
+theme for [Jekyll](http://jekyllrb.com) 3.x and 4.x and adds new functionality.
 
 ### Keep It Simple
 

--- a/jekyll-theme-hydeout.gemspec
+++ b/jekyll-theme-hydeout.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.add_runtime_dependency "jekyll", "~> 3.4"
+  spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0"
   spec.add_runtime_dependency "jekyll-gist", "~> 1.4"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-feed", "~> 0.6"


### PR DESCRIPTION
Relaxes the jekyll dependency in the gemspec file to allow for Jekyll v4.0.