### PR TITLE
Add support for short_title page property. Thuis value, if provided, …

### DIFF
--- a/_includes/page-links.html
+++ b/_includes/page-links.html
@@ -7,7 +7,7 @@
   {% if node.title != null %}
     {% if node.sidebar_link %}
       <a class="page-link {% if page.url == node.url %} active{% endif %}"
-          href="{{ node.url | relative_url }}">{{ node.title }}</a>
+          href="{{ node.url | relative_url }}">{% if node.short_title != null %}{{ node.short_title }}{% else %}{{ node.title }}{% endif %}</a>
     {% endif %}
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
…will be used for sidebar nav menu instead of title. It allows using a shorter text for the link while rpeserving a longertitle to be shown on the page proper