### PR TITLE
Fix a back-link bug

### DIFF
--- a/_includes/back-link.html
+++ b/_includes/back-link.html
@@ -1,6 +1,10 @@
-{% assign back_page = site.pages | find: "name", page.back_page %}
+{% if page.back_page %}
+
+{% assign back_page = site.pages | where: "name", page.back_page | first %}
 {% if back_page != null %}
     <p class="back-link">
     <a href="{{ back_page.url | relative_url }}"><span class="back-arrow icon">{% include svg/back-arrow.svg %}</span>{{ back_page.short_title | default: back_page.title }}</a>
     </p>
+{% endif %}
+
 {% endif %}


### PR DESCRIPTION
A bug, which creates the empty-back-link when the page.back_page property is not declared, has been found.
It seems like the 'find' filter of the liquid does not work properly.
Now, back-link.html uses both 'where' and 'first' filters to create the proper back link, only when the the page.back_page is declared in the current page.