### PR TITLE
Add support for Google Analytics 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You can see the full set of partials you can replace in the
   If you don't want Disqus or want to use something else, override
   `comments.html`.
 
-* For Google Analytics support, define a `google_analytics` variable with
+* For Google Analytics support, you can define a `google_analytics` variable for **Universal Analytics** or a `google_analytics_4` variable for **Google Analytics 4** with
   your property ID in your config file.
 
 There's also a bunch of minor tweaks and adjustments throughout the

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -8,4 +8,14 @@
   ga('create', '{{ site.google_analytics }}', 'auto');
   ga('send', 'pageview');
   </script>
+{% elsif jekyll.environment == 'production' and site.google_analytics_4 %}
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_4 }}"></script>
+  <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics_4 }}');
+  </script>
 {% endif %}


### PR DESCRIPTION
The Google Analytics provides a new kind of property named Google Analytics 4 (GA4) which need to change the javascript to use. This commit uses conditional logic to give consideration to the previous property (Universal Analytics) and new property (GA4).