### PR TITLE
Fix the layout issue with jemoji

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll-include-cache", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,8 @@ plugins:
   - jekyll-feed
   - jekyll-gist
   - jekyll-paginate
+  - jekyll-include-cache
+  - jemoji
 
 # Sidebar link settings
 sidebar_home_link:  true

--- a/_sass/hydeout/_base.scss
+++ b/_sass/hydeout/_base.scss
@@ -127,3 +127,8 @@ input[type='submit'] {
   width: 100%;
   height: 100%;
 }
+
+.emoji {
+  display: initial;
+  margin: initial;
+}


### PR DESCRIPTION
There was an bug that the emoji take place the enitre line itself.
This bug has been fixed by setting the 'display' and 'margin' as
'initial'.